### PR TITLE
add: support for custom project symbols and other fixes

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -6,7 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [1.02]
+## [1.0.3]
+### Changed
+- Allowed custom symbols to be used besides the know ones
+
+### Fix
+- Fixed an issue that when parsing crashes would still use the unity symbols from unity installation instead of the project ones when Strip Engine Code is enabled
+
+
+## [1.0.2]
 ### Changed
 - Moved the Menu to `Window/Analysis/Smart Symbolicate`
 
@@ -18,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Add
 - Initial implementation of the Smart Symbolicate
 
+[1.0.3]: https://github.com/brunomikoski/UnitySmartSymbolicate/releases/tag/v1.0.3
 [1.0.2]: https://github.com/brunomikoski/UnitySmartSymbolicate/releases/tag/v1.0.2
 [1.0.1]: https://github.com/brunomikoski/UnitySmartSymbolicate/releases/tag/v1.0.1
 [1.0.0]: https://github.com/brunomikoski/UnitySmartSymbolicate/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.brunomikoski.unitysmartsymbolicate",
   "displayName": "Smart Symbolicate",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "unity": "2018.4",
   "description": "A tool to help you symbolicate android crashes",
   "keywords": [


### PR DESCRIPTION
### Changed
- Allowed custom symbols to be used besides the know ones

### Fix
- Fixed an issue that when parsing crashes would still use the unity symbols from unity installation instead of the project ones when Strip Engine Code is enabled